### PR TITLE
Remove cache default when used in Next.js runtime

### DIFF
--- a/services/src/auth/fetchSession.ts
+++ b/services/src/auth/fetchSession.ts
@@ -28,7 +28,8 @@ export const fetchSession = async (token: string | null): Promise<AuthUser> => {
   }
 
   const response = await fetch(`${baseUrl}/auth/session`, {
-    headers: { Authorization: `Bearer ${token}` }
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store'
   });
   const user = await response.json();
 


### PR DESCRIPTION
Fetch is overridden by Next.js at runtime and defaults to cache. In Next.js v15, they turned cache off by default so matching it now because some issues I'm seeing when going from anonymous to authenticated routes (even though I refresh token).