### PR TITLE
feat: add encryption config to company preferences

### DIFF
--- a/types/src/dto/company/CompanyPreferences.ts
+++ b/types/src/dto/company/CompanyPreferences.ts
@@ -1,3 +1,4 @@
+import { FileEncryptionConfig } from '../../entities/FileEncryptionConfig';
 import { NotificationType, ProductType } from '../../../prisma';
 import { ImportRosterParams } from '../roster/ImportRosterParams';
 
@@ -37,4 +38,5 @@ export interface CompanyPreferences {
   defaultTimeZone?: string;
   transferConsumerSubmission?: boolean;
   onlyNotificationTypes?: NotificationType[];
+  encryption?: FileEncryptionConfig;
 }

--- a/types/src/entities/FileEncryptionConfig.ts
+++ b/types/src/entities/FileEncryptionConfig.ts
@@ -1,0 +1,28 @@
+export type EncryptionMethod = 'gpg';
+
+export interface FileEncryptionConfig {
+  /**
+   * The encryption method to use (e.g. 'gpg').
+   */
+  method: EncryptionMethod;
+  /**
+   * The secret ARN of the key used for decryption.
+   */
+  decryptionKeySecretArn: string;
+  /**
+   * The secret ARN of the key used for encryption.
+   */
+  encryptionKeySecretArn: string;
+  /**
+   * Passphrase ARN for the private key (optional)
+   */
+  passphraseSecretArn?: string;
+  /**
+   * Indicates if inbound files are encrypted and require decryption (default false).
+   */
+  inboundEncrypted?: boolean;
+  /**
+   * Indicates if outbound files are encrypted and require encryption (default false).
+   */
+  outboundEncrypted?: boolean;
+}

--- a/types/src/entities/FileEncryptionConfig.ts
+++ b/types/src/entities/FileEncryptionConfig.ts
@@ -7,22 +7,16 @@ export interface FileEncryptionConfig {
   method: EncryptionMethod;
   /**
    * The secret ARN of the key used for decryption.
+   * If this is omitted, then files inbound to our system will not be decrypted.
    */
-  decryptionKeySecretArn: string;
+  decryptionKeySecretArn?: string;
   /**
    * The secret ARN of the key used for encryption.
+   * If this is omitted, then files outbound from our system will not be encrypted.
    */
-  encryptionKeySecretArn: string;
+  encryptionKeySecretArn?: string;
   /**
    * Passphrase ARN for the private key (optional)
    */
   passphraseSecretArn?: string;
-  /**
-   * Indicates if inbound files are encrypted and require decryption (default false).
-   */
-  inboundEncrypted?: boolean;
-  /**
-   * Indicates if outbound files are encrypted and require encryption (default false).
-   */
-  outboundEncrypted?: boolean;
 }

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -142,6 +142,7 @@ export type * from './dto/workbench/SearchWorkbenchParams';
 export type * from './dto/workbench/SubmitOrderParams';
 export type * from './dto/workbench/UpdateInactiveFootBody';
 export type * from './entities/AssetExtended';
+export type * from './entities/FileEncryptionConfig'
 export type * from './entities/CatalogProductExtended';
 export type * from './entities/CatalogProductVariantExtended';
 export type * from './entities/ClinicianExtended';


### PR DESCRIPTION
You can now define ahead of time for company-specific encryption strategies