### PR TITLE
Fix browser API mocks for sdk-next tests

### DIFF
--- a/sdk-next/__tests__/camera.test.ts
+++ b/sdk-next/__tests__/camera.test.ts
@@ -1,13 +1,21 @@
 import { requestCameraPermissions } from '../src/media/camera';
 
 describe('requestCameraPermissions', () => {
+  const originalMediaDevices = (navigator as any).mediaDevices;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (navigator as any).mediaDevices = { getUserMedia: jest.fn() };
+  });
+
+  afterAll(() => {
+    (navigator as any).mediaDevices = originalMediaDevices;
   });
 
   it('should resolve if camera access is granted', async () => {
+    const track = { stop: jest.fn() };
     const mockStream = {
-      getTracks: jest.fn(() => [{ stop: jest.fn() }])
+      getTracks: jest.fn(() => [track])
     };
 
     // Mocking navigator.mediaDevices.getUserMedia to resolve with mockStream
@@ -16,7 +24,7 @@ describe('requestCameraPermissions', () => {
     await expect(requestCameraPermissions()).resolves.toBeUndefined();
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: true });
     expect(mockStream.getTracks).toHaveBeenCalled();
-    expect(mockStream.getTracks()[0]?.stop).toHaveBeenCalled();
+    expect(track.stop).toHaveBeenCalled();
   });
 
   it('should reject if camera access is denied', async () => {

--- a/sdk-next/__tests__/getSupportedMimeTypes.test.ts
+++ b/sdk-next/__tests__/getSupportedMimeTypes.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from '@jest/globals';
 import { getSupportedMimeTypes } from '../src/media/getSupportedMimeTypes';
 
 describe('getSupportedMimeTypes', () => {
+  const originalMediaRecorder = (global as any).MediaRecorder;
+
   beforeAll(() => {
-    jest.spyOn(MediaRecorder, 'isTypeSupported').mockImplementation((type: string) => {
+    (global as any).MediaRecorder = { isTypeSupported: jest.fn() };
+    jest
+      .spyOn(MediaRecorder, 'isTypeSupported')
+      .mockImplementation((type: string) => {
       const supportedTypes = [
         'video/webm',
         'video/webm;codecs=vp8',
@@ -23,6 +28,7 @@ describe('getSupportedMimeTypes', () => {
   // Restore the original implementation after all tests
   afterAll(() => {
     (MediaRecorder.isTypeSupported as jest.Mock).mockRestore();
+    (global as any).MediaRecorder = originalMediaRecorder;
   });
 
   test('should return supported MIME types', () => {

--- a/sdk-next/src/media/camera.ts
+++ b/sdk-next/src/media/camera.ts
@@ -5,12 +5,15 @@
  *
  * @returns A promise that resolves with the media stream if permissions are granted.
  */
-export const requestCameraPermissions = (constraints: MediaStreamConstraints = {}): Promise<MediaStream> =>
+export const requestCameraPermissions = (
+  constraints: MediaStreamConstraints = { video: true }
+): Promise<void> =>
   new Promise((resolve, reject) => {
     navigator.mediaDevices
       .getUserMedia(constraints)
       .then((stream) => {
-        resolve(stream);
+        stream.getTracks().forEach((t) => t.stop());
+        resolve();
       })
       .catch((error) => {
         reject(`Camera access denied: ${error.message}`);

--- a/sdk-next/src/media/camera.ts
+++ b/sdk-next/src/media/camera.ts
@@ -5,9 +5,7 @@
  *
  * @returns A promise that resolves with the media stream if permissions are granted.
  */
-export const requestCameraPermissions = (
-  constraints: MediaStreamConstraints = { video: true }
-): Promise<void> =>
+export const requestCameraPermissions = (constraints: MediaStreamConstraints = { video: true }): Promise<void> =>
   new Promise((resolve, reject) => {
     navigator.mediaDevices
       .getUserMedia(constraints)


### PR DESCRIPTION
## Summary
- mock `navigator.mediaDevices` in `camera.test.ts`
- mock `MediaRecorder` in `getSupportedMimeTypes.test.ts`
- stop media tracks and resolve void in `requestCameraPermissions`

## Testing
- `pnpm test` in `packages/hike-sdk/sdk-next`