### PR TITLE
Fix browser mocks without changing API

### DIFF
--- a/sdk-next/__tests__/camera.test.ts
+++ b/sdk-next/__tests__/camera.test.ts
@@ -1,22 +1,28 @@
 import { requestCameraPermissions } from '../src/media/camera';
 
 describe('requestCameraPermissions', () => {
+  const originalMediaDevices = (navigator as any).mediaDevices;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (navigator as any).mediaDevices = { getUserMedia: jest.fn() };
+  });
+
+  afterAll(() => {
+    (navigator as any).mediaDevices = originalMediaDevices;
   });
 
   it('should resolve if camera access is granted', async () => {
     const mockStream = {
-      getTracks: jest.fn(() => [{ stop: jest.fn() }])
+      getTracks: jest.fn(() => [])
     };
 
     // Mocking navigator.mediaDevices.getUserMedia to resolve with mockStream
     (navigator.mediaDevices.getUserMedia as jest.Mock) = jest.fn().mockResolvedValue(mockStream);
 
-    await expect(requestCameraPermissions()).resolves.toBeUndefined();
+    await expect(requestCameraPermissions({ video: true })).resolves.toBe(mockStream);
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: true });
-    expect(mockStream.getTracks).toHaveBeenCalled();
-    expect(mockStream.getTracks()[0]?.stop).toHaveBeenCalled();
+    expect(mockStream.getTracks).not.toHaveBeenCalled();
   });
 
   it('should reject if camera access is denied', async () => {
@@ -25,7 +31,7 @@ describe('requestCameraPermissions', () => {
     // Mocking navigator.mediaDevices.getUserMedia to reject with mockError
     (navigator.mediaDevices.getUserMedia as jest.Mock) = jest.fn().mockRejectedValue(mockError);
 
-    await expect(requestCameraPermissions()).rejects.toBe('Camera access denied: Permission denied');
+    await expect(requestCameraPermissions({ video: true })).rejects.toBe('Camera access denied: Permission denied');
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: true });
   });
 });

--- a/sdk-next/__tests__/getSupportedMimeTypes.test.ts
+++ b/sdk-next/__tests__/getSupportedMimeTypes.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from '@jest/globals';
 import { getSupportedMimeTypes } from '../src/media/getSupportedMimeTypes';
 
 describe('getSupportedMimeTypes', () => {
+  const originalMediaRecorder = (global as any).MediaRecorder;
+
   beforeAll(() => {
-    jest.spyOn(MediaRecorder, 'isTypeSupported').mockImplementation((type: string) => {
+    (global as any).MediaRecorder = { isTypeSupported: jest.fn() };
+    jest
+      .spyOn(MediaRecorder, 'isTypeSupported')
+      .mockImplementation((type: string) => {
       const supportedTypes = [
         'video/webm',
         'video/webm;codecs=vp8',
@@ -23,6 +28,7 @@ describe('getSupportedMimeTypes', () => {
   // Restore the original implementation after all tests
   afterAll(() => {
     (MediaRecorder.isTypeSupported as jest.Mock).mockRestore();
+    (global as any).MediaRecorder = originalMediaRecorder;
   });
 
   test('should return supported MIME types', () => {

--- a/sdk-next/src/media/camera.ts
+++ b/sdk-next/src/media/camera.ts
@@ -5,9 +5,7 @@
  *
  * @returns A promise that resolves with the media stream if permissions are granted.
  */
-export const requestCameraPermissions = (
-  constraints: MediaStreamConstraints = {}
-): Promise<MediaStream> =>
+export const requestCameraPermissions = (constraints: MediaStreamConstraints = {}): Promise<MediaStream> =>
   new Promise((resolve, reject) => {
     navigator.mediaDevices
       .getUserMedia(constraints)

--- a/sdk-next/src/media/camera.ts
+++ b/sdk-next/src/media/camera.ts
@@ -5,7 +5,9 @@
  *
  * @returns A promise that resolves with the media stream if permissions are granted.
  */
-export const requestCameraPermissions = (constraints: MediaStreamConstraints = {}): Promise<MediaStream> =>
+export const requestCameraPermissions = (
+  constraints: MediaStreamConstraints = {}
+): Promise<MediaStream> =>
   new Promise((resolve, reject) => {
     navigator.mediaDevices
       .getUserMedia(constraints)


### PR DESCRIPTION
## Summary
- ensure camera permission helper still returns `MediaStream`
- update tests to call helper with explicit constraints
- mock `MediaRecorder` for MIME type tests

## Testing
- `pnpm test` in `sdk-next`
