### PR TITLE
Add clinician update support to SDK

### DIFF
--- a/services/src/api/clinician.service.ts
+++ b/services/src/api/clinician.service.ts
@@ -3,6 +3,7 @@ import {
   Clinician,
   ClinicianExtended,
   CreateClinicianParams,
+  UpdateClinicianParams,
   GetCliniciansParams,
   PagedResponse
 } from '@hike/types';
@@ -48,6 +49,18 @@ export const fetchUnassignedClinicians = async (name: string): Promise<Clinician
 export const assignClinician = async ({ clinicianId, userId }: AssignClinicianParams): Promise<Clinician> => {
   try {
     const response = await backendApi.post(`clinician/assign/${clinicianId}/user/${userId}`);
+    return response.data;
+  } catch (error) {
+    throw toHikeError(error);
+  }
+};
+
+export const updateClinician = async (
+  clinicianId: string,
+  params: UpdateClinicianParams
+): Promise<Clinician> => {
+  try {
+    const response = await backendApi.patch(`clinician/${clinicianId}`, params);
     return response.data;
   } catch (error) {
     throw toHikeError(error);

--- a/types/src/dto/clinician/UpdateClinicianParams.ts
+++ b/types/src/dto/clinician/UpdateClinicianParams.ts
@@ -1,0 +1,3 @@
+export interface UpdateClinicianParams {
+  noAuthNeeded?: boolean;
+}

--- a/types/src/entities/ClinicianExtended.ts
+++ b/types/src/entities/ClinicianExtended.ts
@@ -1,5 +1,6 @@
 import type { Clinician, User } from '../../prisma';
 
 export type ClinicianExtended = Clinician & {
+  noAuthNeeded?: boolean;
   user: Pick<User, 'id' | 'email' | 'photoUrl'> | null;
 };

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -44,6 +44,7 @@ export * from './dto/catalog/GetVendorsParams';
 export * from './dto/clinician/AssignClinicianParams';
 export * from './dto/clinician/CreateClinicianParams';
 export * from './dto/clinician/GetCliniciansParams';
+export * from './dto/clinician/UpdateClinicianParams';
 export * from './dto/company/AddCompanyParams';
 export * from './dto/company/ClinicalFlowType';
 export * from './dto/company/CompanyPortal';

--- a/ui/src/hooks/clinician/useUpdateClinician.ts
+++ b/ui/src/hooks/clinician/useUpdateClinician.ts
@@ -1,0 +1,17 @@
+import { HikeError, updateClinician } from '@hike/services';
+import { Clinician, UpdateClinicianParams } from '@hike/types';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+
+interface UpdateClinicianContext {
+  clinicianId: string;
+  body: UpdateClinicianParams;
+}
+
+export const useUpdateClinician = (
+  options?: UseMutationOptions<Clinician, HikeError<null>, UpdateClinicianContext>
+) =>
+  useMutation({
+    mutationKey: ['updateClinician'],
+    mutationFn: async ({ clinicianId, body }) => await updateClinician(clinicianId, body),
+    ...options
+  });

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -47,6 +47,7 @@ export * from './hooks/clinician/useClinicians';
 export * from './hooks/clinician/useCreateClinician';
 export * from './hooks/clinician/useUnassignedClinician';
 export * from './hooks/clinician/useUnassignedClinicians';
+export * from './hooks/clinician/useUpdateClinician';
 export * from './hooks/company/useAddCompany';
 export * from './hooks/company/useCompanies';
 export * from './hooks/company/useCompaniesByName';


### PR DESCRIPTION
## Summary
- add `UpdateClinicianParams` type
- expose the new type from `@hike/types`
- extend `ClinicianExtended` with optional `noAuthNeeded`
- implement `updateClinician` service
- add `useUpdateClinician` hook and export it

## Testing
- `pnpm build`
- `pnpm test`

Original prompt: Using the below patch from hike-mono, create the associated code needed in the SDK. The original chat is here: https://chatgpt.com/s/cd_682d6258fc9481918df84800f56bac8a