### PR TITLE
feat(utils): introduce workflow helper

### DIFF
--- a/utils/__tests__/workflow.test.ts
+++ b/utils/__tests__/workflow.test.ts
@@ -1,0 +1,95 @@
+import { Workflow, WorkflowError } from '../src/helpers/workflow';
+
+describe('Workflow', () => {
+  it('executes steps sequentially', async () => {
+    const ctx = { count: 0 };
+    await new Workflow(ctx)
+      .addStep('inc1', (c) => {
+        c.count += 1;
+      })
+      .addStep('inc2', (c) => {
+        c.count += 1;
+      })
+      .run();
+
+    expect(ctx.count).toBe(2);
+  });
+
+  it('runs conditional steps when condition is true', async () => {
+    const ctx = { run: true, value: 0 };
+    await new Workflow(ctx)
+      .addConditionalStep(
+        'conditional',
+        (c) => c.run,
+        (c) => {
+          c.value = 42;
+        }
+      )
+      .run();
+
+    expect(ctx.value).toBe(42);
+  });
+
+  it('skips conditional steps when condition is false', async () => {
+    const ctx = { run: false, value: 0 };
+    await new Workflow(ctx)
+      .addConditionalStep(
+        'conditional',
+        (c) => c.run,
+        (c) => {
+          c.value = 42;
+        }
+      )
+      .run();
+
+    expect(ctx.value).toBe(0);
+  });
+
+  it('executes parallel steps', async () => {
+    const ctx = { actions: [] as string[] };
+    await new Workflow(ctx)
+      .addParallelSteps([
+        { name: 'a', fn: (c) => c.actions.push('a') },
+        { name: 'b', fn: (c) => c.actions.push('b') }
+      ])
+      .run();
+
+    expect(ctx.actions.sort()).toEqual(['a', 'b']);
+  });
+
+  it('supports nested workflows', async () => {
+    const ctx = { count: 0 };
+    const child = new Workflow<typeof ctx>({ count: 0 }).addStep('childStep', (c) => {
+      c.count += 1;
+    });
+
+    await new Workflow(ctx).addWorkflow('child', child).run();
+
+    expect(ctx.count).toBe(1);
+  });
+
+  it('stops execution and calls error handler on failure', async () => {
+    const ctx = { count: 0 };
+    const errors: WorkflowError[] = [];
+
+    await new Workflow(ctx)
+      .addStep('ok', (c) => {
+        c.count += 1;
+      })
+      .addStep('fail', () => {
+        throw new Error('boom');
+      })
+      .addStep('after', (c) => {
+        c.count += 1;
+      })
+      .onError((err) => {
+        errors.push(err);
+      })
+      .run();
+
+    expect(ctx.count).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(WorkflowError);
+    expect(errors[0].step).toBe('fail');
+  });
+});

--- a/utils/src/helpers/workflow.ts
+++ b/utils/src/helpers/workflow.ts
@@ -1,0 +1,81 @@
+export type StepFn<TContext> = (ctx: TContext) => void | Promise<void>;
+export type ConditionFn<TContext> = (ctx: TContext) => boolean | Promise<boolean>;
+
+interface WorkflowStep<TContext> {
+  name: string;
+  fn: StepFn<TContext>;
+  condition?: ConditionFn<TContext>;
+}
+
+export class WorkflowError extends Error {
+  readonly step: string;
+  readonly cause: Error;
+
+  constructor(step: string, cause: Error) {
+    super(`Step "${step}" failed: ${cause.message}`);
+    this.step = step;
+    this.cause = cause;
+  }
+}
+
+export class Workflow<TContext> {
+  private steps: WorkflowStep<TContext>[] = [];
+  private errorHandler?: (error: WorkflowError, ctx: TContext) => void | Promise<void>;
+
+  constructor(private ctx: TContext) {}
+
+  addStep(name: string, fn: StepFn<TContext>): this {
+    this.steps.push({ name, fn });
+    return this;
+  }
+
+  addConditionalStep(name: string, condition: ConditionFn<TContext>, fn: StepFn<TContext>): this {
+    this.steps.push({ name, fn, condition });
+    return this;
+  }
+
+  addWorkflow(name: string, workflow: Workflow<TContext>): this {
+    return this.addStep(name, async (ctx) => {
+      await workflow.cloneWithContext(ctx).run();
+    });
+  }
+
+  addParallelSteps(steps: { name: string; fn: StepFn<TContext> }[]): this {
+    return this.addStep('ParallelGroup', async (ctx) => {
+      await Promise.all(steps.map((s) => s.fn(ctx)));
+    });
+  }
+
+  onError(handler: (error: WorkflowError, ctx: TContext) => void | Promise<void>): this {
+    this.errorHandler = handler;
+    return this;
+  }
+
+  async run(): Promise<TContext> {
+    for (const step of this.steps) {
+      try {
+        const shouldRun = step.condition ? await step.condition(this.ctx) : true;
+        if (shouldRun) {
+          await step.fn(this.ctx);
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const workflowError = new WorkflowError(step.name, error);
+        if (this.errorHandler) {
+          await this.errorHandler(workflowError, this.ctx);
+        } else {
+          throw workflowError;
+        }
+        break;
+      }
+    }
+    return this.ctx;
+  }
+
+  cloneWithContext(ctx: TContext): Workflow<TContext> {
+    const clone = new Workflow(ctx);
+    clone.steps = [...this.steps];
+    clone.errorHandler = this.errorHandler;
+    return clone;
+  }
+}

--- a/utils/src/index.ts
+++ b/utils/src/index.ts
@@ -46,3 +46,4 @@ export * from './helpers/streamToString';
 export * from './helpers/truncateMiddle';
 export * from './helpers/validateEmail';
 export * from './helpers/validatePhone';
+export * from './helpers/workflow';


### PR DESCRIPTION
## Summary
- add export for workflow helper
- implement chainable Workflow with conditional, parallel, nested steps and error handling

## Testing
- `pnpm --filter @hike/utils lint`
- `npx prettier --check utils/src/helpers/workflow.ts utils/__tests__/workflow.test.ts utils/src/index.ts`
- `pnpm --filter @hike/utils test` *(fails: Cannot find module '@hike/types')*
- `pnpm --filter @hike/utils test -- workflow.test.ts`

## Original Prompt
Create an elegant, robust, flexible workflow utility that allows to chain actions in various way and exits on errors. This is the API I'm thinking:

```
const workflow = new Workflow({ context: { patientId: "123" } })
  .addStep("Fax Physician", async (ctx) => {
    await faxService.send(ctx.patientId);
  })
  .addConditionalStep("Notify Admin", (ctx) => !ctx.faxSent, async (ctx) => {
    await notifyAdmin(ctx.patientId);
  })
  .onError((err, ctx) => console.error(err))
  .run();
```

This is a draft implementation but make it better:

```
type StepFn<TContext> = (ctx: TContext) => Promise<void> | void;
type ConditionFn<TContext> = (ctx: TContext) => boolean;

class Workflow<TContext = any> {
  private steps: { name: string; fn: StepFn<TContext>; condition?: ConditionFn<TContext> }[] = [];
  private errorHandler?: (error: Error, ctx: TContext) => void;

  constructor(private ctx: TContext) {}

  addStep(name: string, fn: StepFn<TContext>) {
    this.steps.push({ name, fn });
    return this;
  }

  addConditionalStep(name: string, condition: ConditionFn<TContext>, fn: StepFn<TContext>) {
    this.steps.push({ name, fn, condition });
    return this;
  }

  addWorkflow(name: string, workflow: Workflow<TContext>) {
    this.steps.push({
      name,
      fn: async (ctx) => {
        await workflow.cloneWithContext(ctx).run();
      },
    });
    return this;
  }

  addParallelSteps(steps: Array<{ name: string; fn: StepFn<TContext> }>) {
    this.steps.push({
      name: "ParallelGroup",
      fn: async (ctx) => Promise.all(steps.map((s) => s.fn(ctx))),
    });
    return this;
  }

  onError(handler: (error: Error, ctx: TContext) => void) {
    this.errorHandler = handler;
    return this;
  }

  async run() {
    for (const step of this.steps) {
      try {
        if (step.condition && !step.condition(this.ctx)) continue;
        await step.fn(this.ctx);
      } catch (error) {
        if (this.errorHandler) this.errorHandler(error as Error, this.ctx);
        else throw error;
      }
    }
    return this.ctx;
  }

  cloneWithContext(ctx: TContext) {
    const clone = new Workflow<TContext>(ctx);
    clone.steps = [...this.steps];
    clone.errorHandler = this.errorHandler;
    return clone;
  }
}
```


------
https://chatgpt.com/codex/tasks/task_b_6899d97934908327be4c85d4efeb24f3